### PR TITLE
Remove new type hinting syntax: support down to Python v3.7

### DIFF
--- a/lgui/components/capacitor.py
+++ b/lgui/components/capacitor.py
@@ -1,4 +1,6 @@
 
+from typing import Union
+
 from .component import Component
 
 class Capacitor(Component):
@@ -8,14 +10,14 @@ class Capacitor(Component):
     Parameters
     ----------
 
-    value: str | int | float
+    value: Union[str, int, float]
         The value of the capacitor.
     """
 
     TYPE = "C"
     NAME = "Capacitor"
 
-    def __init__(self, value: str | int | float):
+    def __init__(self, value: Union[str, int, float]):
 
         super().__init__(value)
 

--- a/lgui/components/component.py
+++ b/lgui/components/component.py
@@ -5,6 +5,7 @@ Defines the components that lgui can simulate
 import numpy as np
 import ipycanvas as canvas
 
+from typing import Union
 from abc import ABC, abstractmethod
 
 class Node:
@@ -30,14 +31,14 @@ class Component(ABC):
     Parameters
     ----------
 
-    value: str | int | float
+    value: Union[str, int, float]
         The value of the component.
     """
 
     HEIGHT = 4
     next_id: int = 0
 
-    def __init__(self, value: str | int | float):
+    def __init__(self, value: Union[str, int, float]):
 
         self.value: str = value
         self.ports: list[Node] = [Node(), Node()]

--- a/lgui/components/current_supply.py
+++ b/lgui/components/current_supply.py
@@ -1,6 +1,8 @@
 
 import numpy as np
 
+from typing import Union
+
 from .component import Component
 
 class CurrentSupply(Component):
@@ -10,14 +12,14 @@ class CurrentSupply(Component):
     Parameters
     ----------
 
-    value: str | int | float
+    value: Union[str, int, float]
         The value of the current supply.
     """
 
     TYPE = "I"
     NAME = "Current Supply"
 
-    def __init__(self, value: str | int | float):
+    def __init__(self, value: Union[str, int, float]):
 
         super().__init__(value)
 

--- a/lgui/components/inductor.py
+++ b/lgui/components/inductor.py
@@ -1,6 +1,8 @@
 
 import numpy as np
 
+from typing import Union
+
 from .component import Component
 
 class Inductor(Component):
@@ -10,14 +12,14 @@ class Inductor(Component):
     Parameters
     ----------
 
-    value: str | int | float
+    value: Union[str, int, float]
         The value of the inductor.
     """
 
     TYPE = "L"
     NAME = "Inductor"
 
-    def __init__(self, value: str | int | float):
+    def __init__(self, value: Union[str, int, float]):
 
         super().__init__(value)
 

--- a/lgui/components/resistor.py
+++ b/lgui/components/resistor.py
@@ -1,4 +1,6 @@
 
+from typing import Union
+
 from .component import Component
 
 class Resistor(Component):
@@ -8,14 +10,14 @@ class Resistor(Component):
     Parameters
     ----------
 
-    value: str | int | float
+    value: Union[str, int, float]
         The value of the resistor.
     """
 
     TYPE = "R"
     NAME = "Resistor"
 
-    def __init__(self, value: str | int | float):
+    def __init__(self, value: Union[str, int, float]):
 
         super().__init__(value)
 

--- a/lgui/components/voltage_supply.py
+++ b/lgui/components/voltage_supply.py
@@ -1,6 +1,8 @@
 
 import numpy as np
 
+from typing import Union
+
 from .component import Component
 
 class VoltageSupply(Component):
@@ -10,14 +12,14 @@ class VoltageSupply(Component):
     Parameters
     ----------
 
-    value: str | int | float
+    value: Union[str, int, float]
         The value of the voltage supply.
     """
 
     TYPE = "V"
     NAME = "Voltage Supply"
 
-    def __init__(self, value: str | int | float):
+    def __init__(self, value: Union[str, int, float]):
 
         super().__init__(value)
 

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,11 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "numpy",
         "lcapy",
+        "numpy",
         "ipywidgets",
         "IPython",
         "ipycanvas"
     ],
-    python_requires=">=3.10" # due to match statements
+    python_requires=">=3.7" # matched with lcapy
 )


### PR DESCRIPTION
This pull request removes the new type hinting syntax that limits lgui to only be used with version of Python >= 3.10.
The match statements previously cited as the limiting factor were removed in the component abstraction pull requestion (#12).